### PR TITLE
Default to rad

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use the package to plot nice prototype plots. In some case, you might have to in
 More plots will be added once I'll need them.
 
 #### Current plots
-- PhasorDiagram[*scaling factor*,*angle (deg)*]: a simple phasor diagram of two vectors, with the second one rotated and scaled.
+- PhasorDiagram[*scaling factor*,*angle*]: a simple phasor diagram of two vectors, with the second one rotated and scaled.
 
 ### Installing
 In order to use the package, you need a working copy of Wolfram Mathematica.

--- a/prettyplots.wl
+++ b/prettyplots.wl
@@ -9,9 +9,9 @@ BeginPackage["PrettyPlots`"]
 
 
  PhasorDiagram::usage=
- "PhasorPlot[inverse scaling factor, argument]
+ "PhasorDiagram[inverse scaling factor, argument]
 Plot a phasor diagram of voltage and current.
-Scale current by the scaling factor and rotate it by the argument (in deg)"
+Scale current by the scaling factor and rotate it by the argument"
  PhasorDiagram[sf_,argz_]:=Module[{plotBasis,currentPhasor,voltagePhasor, curr, osf},
  osf=1.32;
 plotBasis = PolarPlot[1,{curr,0,1},
@@ -30,7 +30,7 @@ Arrow[{{0,0},{osf,0}}],
 currentPhasor = Graphics[{Red,Thick,
 Rotate[
 Arrow[{{0,0},{osf*sf,0}}],
-argz*Pi/180,{0,0}
+argz,{0,0}
 ]
 }];
 Show[plotBasis,voltagePhasor,currentPhasor]


### PR DESCRIPTION
Usually you want a dimensionless number in context of angles to mean radians. This convention is used all over Mathematica, eg. all trigonometric functions expect arguments in radians.

If you want to represent an angle in degrees, simply multiply by the [degree](https://reference.wolfram.com/language/ref/Degree.html) symbol, like so: `PhasorDiagram[2, 75°]`. This also makes the representation more explicit.
